### PR TITLE
Add the ability to use a custom input component

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -20,6 +20,7 @@ export interface PhoneInputProps {
   onChangeText?: (text: string) => void;
   onChangeFormattedText?: (text: string) => void;
   renderDropdownImage?: JSX.Element;
+  renderInput?: JSX.Element<Partial<TextInputProps>>;
   containerStyle?: StyleProp<ViewStyle>;
   textContainerStyle?: StyleProp<ViewStyle>;
   textInputProps?: TextInputProps;

--- a/lib/index.js
+++ b/lib/index.js
@@ -143,6 +143,7 @@ export default class PhoneInput extends PureComponent {
 
   render() {
     const {
+      renderInput,
       withShadow,
       withDarkTheme,
       codeTextStyle,
@@ -219,18 +220,28 @@ export default class PhoneInput extends PureComponent {
                 style={[styles.codeText, codeTextStyle ? codeTextStyle : {}]}
               >{`+${code}`}</Text>
             )}
-            <TextInput
-              style={[styles.numberText, textInputStyle ? textInputStyle : {}]}
-              placeholder={placeholder ? placeholder : "Phone Number"}
-              onChangeText={this.onChangeText}
-              value={number}
-              editable={disabled ? false : true}
-              selectionColor="black"
-              keyboardAppearance={withDarkTheme ? "dark" : "default"}
-              keyboardType="number-pad"
-              autoFocus={autoFocus}
-              {...textInputProps}
-            />
+            {renderInput ? (
+              renderInput({
+                onChangeText: this.onChangeText,
+                value: number,
+                disabled,
+                keyboardAppearance: withDarkTheme ? 'dark' : 'default',
+                keyboardType: 'number-pad',
+              })
+            ) : (
+              <TextInput
+                style={[styles.numberText, textInputStyle ? textInputStyle : {}]}
+                placeholder={placeholder ? placeholder : "Phone Number"}
+                onChangeText={this.onChangeText}
+                value={number}
+                editable={disabled ? false : true}
+                selectionColor="black"
+                keyboardAppearance={withDarkTheme ? "dark" : "default"}
+                keyboardType="number-pad"
+                autoFocus={autoFocus}
+                {...textInputProps}
+              />
+            )}
           </View>
         </View>
       </CountryModalProvider>


### PR DESCRIPTION
Add a new `renderInput` prop which if provided, will be invoked to render the provided input in place of the internal input component. This allows consumers to render any input component they prefer